### PR TITLE
Disable cache in Ievkit::Job by default

### DIFF
--- a/app/services/ievkit_views/report.rb
+++ b/app/services/ievkit_views/report.rb
@@ -4,10 +4,11 @@ module IevkitViews
     include IevkitViews::ApplicationHelper
     attr_reader :result, :datas, :search
 
-    def initialize(referential, link_action, type_report, link_validation = nil, search = nil)
+    def initialize(referential, link_action, type_report, link_validation = nil, search = nil, disable_cache = true)
       @datas = {}
       @result = :error
       ievkit = ::Ievkit::Job.new(referential)
+      ievkit.disable_cache = disable_cache
       report = ievkit.get_job(link_action)
       @report = report[type_report] if report
       @validation = link_validation ? ievkit.get_job(link_validation) : nil


### PR DESCRIPTION
Disable cache by default to be able to use ievkit job without Redis.
