### PR TITLE
Fix issue with reading errors from validation report

### DIFF
--- a/app/services/ievkit_views/report.rb
+++ b/app/services/ievkit_views/report.rb
@@ -69,7 +69,7 @@ module IevkitViews
     def errors
       clean_errors = []
       return clean_errors unless @validation
-      errors = @validation['validation_report']['errors']
+      errors = @validation['validation_report']['result']['errors']
       return clean_errors unless errors
       errors.each do |error|
         error = key_to_sym(error)


### PR DESCRIPTION
Access validation report errors by key `validation_report.result.errors`. Required change to be able to use chouette2 with chouette (iev) that is migrated to v3.4.
